### PR TITLE
Set which AZs for module to manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "default_vpc" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| azs | List of AZs to manage using only the letters, not full AZ name | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c",<br>  "d"<br>]</pre> | no |
 | region | AWS Region | `string` | `"us-west-2"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -6,39 +6,14 @@ resource "aws_default_vpc" "default" {
   }
 }
 
-resource "aws_default_subnet" "default_az1" {
-  availability_zone = "${var.region}a"
+
+resource "aws_default_subnet" "default_azs" {
+  count = length(var.azs)
+  availability_zone = "${var.region}${var.azs[count.index]}"
 
   tags = {
     Automation = "terraform"
-    Name       = "Default subnet for ${var.region}a"
-  }
-}
-
-resource "aws_default_subnet" "default_az2" {
-  availability_zone = "${var.region}b"
-
-  tags = {
-    Automation = "terraform"
-    Name       = "Default subnet for ${var.region}b"
-  }
-}
-
-resource "aws_default_subnet" "default_az3" {
-  availability_zone = "${var.region}c"
-
-  tags = {
-    Automation = "terraform"
-    Name       = "Default subnet for ${var.region}c"
-  }
-}
-
-resource "aws_default_subnet" "default_az4" {
-  availability_zone = "${var.region}d"
-
-  tags = {
-    Automation = "terraform"
-    Name       = "Default subnet for ${var.region}d"
+    Name       = "Default subnet for ${var.region}${var.azs[count.index]}"
   }
 }
 
@@ -47,12 +22,7 @@ resource "aws_default_network_acl" "default" {
 
   default_network_acl_id = aws_default_vpc.default.default_network_acl_id
 
-  subnet_ids = [
-    aws_default_subnet.default_az1.id,
-    aws_default_subnet.default_az2.id,
-    aws_default_subnet.default_az3.id,
-    aws_default_subnet.default_az4.id,
-  ]
+  subnet_ids = aws_default_subnet.default_azs.*.id
 
   tags = {
     Automation = "terraform"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_default_vpc" "default" {
 
 
 resource "aws_default_subnet" "default_azs" {
-  count = length(var.azs)
+  count             = length(var.azs)
   availability_zone = "${var.region}${var.azs[count.index]}"
 
   tags = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,12 +15,7 @@ output "security_group" {
 
 output "subnets" {
   description = "The Default Subnets"
-  value = [
-    aws_default_subnet.default_az1,
-    aws_default_subnet.default_az2,
-    aws_default_subnet.default_az3,
-    aws_default_subnet.default_az4,
-  ]
+  value = "aws_default_subnet.default_azs"
 }
 
 output "vpc" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "security_group" {
 
 output "subnets" {
   description = "The Default Subnets"
-  value = "aws_default_subnet.default_azs"
+  value       = "aws_default_subnet.default_azs"
 }
 
 output "vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,9 @@ variable "region" {
   type        = string
   default     = "us-west-2"
 }
+
+variable "azs" {
+  description = "List of AZs to manage using only the letters, not full AZ name"
+  type        = list
+  default     = ["a", "b", "c", "d"]
+}


### PR DESCRIPTION
Related Issue: https://github.com/trussworks/terraform-aws-default-vpc/issues/1

This PR address the issue by allowing the module caller to specify which AZs to manage. 

example:
```
 module "default_vpc" {
  #source  = "trussworks/default-vpc/aws"

   region = var.region
   azs    = ["a", "b", "c"] # new var
 }
```

The plan for this change for existing users is a destroy of the resources and creation. Since these are the "default" resources TF won't destroy, even though the plan indicates so.